### PR TITLE
Exam Activity Timeline Visualization

### DIFF
--- a/app/admin/page.tsx
+++ b/app/admin/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link"
 import { ClipboardList, ShieldCheck } from "lucide-react"
 
+import { AdminExamActivityTimelineSection } from "@/components/admin/admin-exam-activity-timeline-section"
 import { AdminStatsOverviewSection } from "@/components/admin/admin-stats-overview-section"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
@@ -69,6 +70,16 @@ export default function AdminHomePage() {
           </p>
         </div>
         <AdminStatsOverviewSection />
+      </div>
+
+      <div className="space-y-3">
+        <div>
+          <h3 className="text-xl font-semibold tracking-tight">Exam Activity Timeline</h3>
+          <p className="text-sm text-muted-foreground">
+            Analyze testing trends, pass/fail distribution, and peak activity periods.
+          </p>
+        </div>
+        <AdminExamActivityTimelineSection />
       </div>
     </div>
   )

--- a/app/api/admin/stats/timeline/route.ts
+++ b/app/api/admin/stats/timeline/route.ts
@@ -1,0 +1,154 @@
+import { ConvexHttpClient } from "convex/browser";
+import { z } from "zod";
+
+import { api } from "@/convex/_generated/api";
+import { adminApiErrorResponse, withAdminApiGuard } from "@/lib/api/admin-handler";
+
+const STATS_TIMELINE_CACHE_TTL_MS = 5 * 60 * 1000;
+
+const timelineQuerySchema = z.object({
+  range: z.enum(["7d", "30d", "90d"]).default("30d"),
+  view: z.enum(["daily", "weekly", "monthly"]).default("daily"),
+  timeZone: z.string().trim().min(1).max(100).optional(),
+});
+
+interface AdminStatsTimelinePoint {
+  periodKey: string;
+  label: string;
+  rangeLabel: string;
+  totalExams: number;
+  passedExams: number;
+  failedExams: number;
+  passRatePercent: number;
+  isPeak: boolean;
+}
+
+interface AdminStatsTimelinePayload {
+  range: "7d" | "30d" | "90d";
+  view: "daily" | "weekly" | "monthly";
+  timeZone: string;
+  points: AdminStatsTimelinePoint[];
+  peakTotalExams: number;
+  generatedAt: number;
+}
+
+interface AdminStatsTimelineResponse {
+  success: true;
+  data: AdminStatsTimelinePayload;
+}
+
+const timelineStatsCache = new Map<
+  string,
+  {
+    data: AdminStatsTimelinePayload;
+    expiresAt: number;
+  }
+>();
+
+function responseHeaders(cacheStatus: "hit" | "miss"): HeadersInit {
+  return {
+    "Cache-Control": "private, max-age=300, stale-while-revalidate=30",
+    "X-Admin-Stats-Timeline-Cache": cacheStatus,
+  };
+}
+
+function isValidTimeZone(timeZone: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function normalizeTimeZone(timeZone?: string): string {
+  if (!timeZone) {
+    return "UTC";
+  }
+
+  return isValidTimeZone(timeZone) ? timeZone : "UTC";
+}
+
+export const GET = withAdminApiGuard(async (req, { convexToken }) => {
+  const url = new URL(req.url);
+  const parsedQuery = timelineQuerySchema.safeParse({
+    range: url.searchParams.get("range") ?? undefined,
+    view: url.searchParams.get("view") ?? undefined,
+    timeZone: url.searchParams.get("timeZone") ?? undefined,
+  });
+
+  if (!parsedQuery.success) {
+    return adminApiErrorResponse(400, "INVALID_QUERY", "Invalid timeline query parameters.");
+  }
+
+  const normalizedTimeZone = normalizeTimeZone(parsedQuery.data.timeZone);
+  const cacheKey = `${parsedQuery.data.range}:${parsedQuery.data.view}:${normalizedTimeZone}`;
+  const now = Date.now();
+
+  const cached = timelineStatsCache.get(cacheKey);
+  if (cached && cached.expiresAt > now) {
+    const body: AdminStatsTimelineResponse = {
+      success: true,
+      data: cached.data,
+    };
+
+    return Response.json(body, {
+      status: 200,
+      headers: responseHeaders("hit"),
+    });
+  }
+
+  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+  if (!convexUrl) {
+    return adminApiErrorResponse(
+      500,
+      "SERVER_MISCONFIGURED",
+      "Convex URL is not configured."
+    );
+  }
+
+  try {
+    const convex = new ConvexHttpClient(convexUrl);
+    convex.setAuth(convexToken);
+
+    const timeline = await convex.query(api.exams.getAdminExamActivityTimeline, {
+      range: parsedQuery.data.range,
+      view: parsedQuery.data.view,
+      timeZone: normalizedTimeZone,
+    });
+
+    if (!timeline) {
+      return adminApiErrorResponse(403, "FORBIDDEN", "Administrator access is required.");
+    }
+
+    const payload: AdminStatsTimelinePayload = {
+      range: timeline.range,
+      view: timeline.view,
+      timeZone: timeline.timeZone,
+      points: timeline.points,
+      peakTotalExams: timeline.peakTotalExams,
+      generatedAt: timeline.generatedAt,
+    };
+
+    timelineStatsCache.set(cacheKey, {
+      data: payload,
+      expiresAt: now + STATS_TIMELINE_CACHE_TTL_MS,
+    });
+
+    const body: AdminStatsTimelineResponse = {
+      success: true,
+      data: payload,
+    };
+
+    return Response.json(body, {
+      status: 200,
+      headers: responseHeaders("miss"),
+    });
+  } catch {
+    return adminApiErrorResponse(
+      500,
+      "INTERNAL_ERROR",
+      "Failed to fetch admin exam activity timeline."
+    );
+  }
+});

--- a/components/admin/admin-exam-activity-timeline-section.tsx
+++ b/components/admin/admin-exam-activity-timeline-section.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useCallback, useEffect, useMemo, useState } from "react";
+
+import {
+  AdminExamActivityTimeline,
+  type AdminStatsTimelineData,
+  type AdminTimelineRange,
+  type AdminTimelineView,
+} from "@/components/admin/admin-exam-activity-timeline";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+
+const TIMELINE_REFRESH_INTERVAL_MS = 30_000;
+
+interface AdminTimelineSuccessResponse {
+  success: true;
+  data: AdminStatsTimelineData;
+}
+
+interface AdminTimelineErrorResponse {
+  success: false;
+  error?: {
+    message?: string;
+  };
+}
+
+const dateRangeOptions: Array<{ value: AdminTimelineRange; label: string }> = [
+  { value: "7d", label: "Last 7 Days" },
+  { value: "30d", label: "Last 30 Days" },
+  { value: "90d", label: "Last 90 Days" },
+];
+
+const timelineViewOptions: Array<{ value: AdminTimelineView; label: string }> = [
+  { value: "daily", label: "Daily" },
+  { value: "weekly", label: "Weekly" },
+  { value: "monthly", label: "Monthly" },
+];
+
+export function AdminExamActivityTimelineSection() {
+  const [range, setRange] = useState<AdminTimelineRange>("30d");
+  const [view, setView] = useState<AdminTimelineView>("daily");
+  const [timeline, setTimeline] = useState<AdminStatsTimelineData | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const timeZone = useMemo(
+    () => Intl.DateTimeFormat().resolvedOptions().timeZone || "UTC",
+    []
+  );
+
+  const fetchTimeline = useCallback(
+    async (isBackgroundRefresh: boolean) => {
+      if (!isBackgroundRefresh) {
+        setIsLoading(true);
+      }
+
+      try {
+        const params = new URLSearchParams({
+          range,
+          view,
+          timeZone,
+        });
+
+        const response = await fetch(`/api/admin/stats/timeline?${params.toString()}`, {
+          method: "GET",
+          cache: "no-store",
+          credentials: "same-origin",
+          headers: {
+            Accept: "application/json",
+          },
+        });
+
+        const body = (await response.json()) as
+          | AdminTimelineSuccessResponse
+          | AdminTimelineErrorResponse;
+
+        if (!response.ok) {
+          const message =
+            body && "error" in body && body.error?.message
+              ? body.error.message
+              : "Unable to load exam activity timeline.";
+          throw new Error(message);
+        }
+
+        if (!body || !("success" in body) || !body.success || !("data" in body)) {
+          throw new Error("Unexpected exam activity timeline response.");
+        }
+
+        setTimeline(body.data);
+        setErrorMessage(null);
+      } catch (error) {
+        const message =
+          error instanceof Error ? error.message : "Unable to load exam activity timeline.";
+        setErrorMessage(message);
+      } finally {
+        if (!isBackgroundRefresh) {
+          setIsLoading(false);
+        }
+      }
+    },
+    [range, timeZone, view]
+  );
+
+  useEffect(() => {
+    void fetchTimeline(false);
+  }, [fetchTimeline]);
+
+  useEffect(() => {
+    const intervalId = setInterval(() => {
+      void fetchTimeline(true);
+    }, TIMELINE_REFRESH_INTERVAL_MS);
+
+    return () => {
+      clearInterval(intervalId);
+    };
+  }, [fetchTimeline]);
+
+  return (
+    <div className="space-y-3">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <Tabs
+          value={range}
+          onValueChange={(nextValue) => setRange(nextValue as AdminTimelineRange)}
+          aria-label="Timeline date range"
+        >
+          <TabsList className="grid w-full grid-cols-3 md:w-auto">
+            {dateRangeOptions.map((option) => (
+              <TabsTrigger key={option.value} value={option.value} aria-label={option.label}>
+                {option.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+
+        <Tabs
+          value={view}
+          onValueChange={(nextValue) => setView(nextValue as AdminTimelineView)}
+          aria-label="Timeline grouping view"
+        >
+          <TabsList className="grid w-full grid-cols-3 md:w-auto">
+            {timelineViewOptions.map((option) => (
+              <TabsTrigger key={option.value} value={option.value} aria-label={option.label}>
+                {option.label}
+              </TabsTrigger>
+            ))}
+          </TabsList>
+        </Tabs>
+      </div>
+
+      {errorMessage ? (
+        <p className="text-sm text-destructive" role="status" aria-live="polite">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <AdminExamActivityTimeline data={timeline} isLoading={isLoading} />
+    </div>
+  );
+}

--- a/components/admin/admin-exam-activity-timeline.tsx
+++ b/components/admin/admin-exam-activity-timeline.tsx
@@ -1,0 +1,203 @@
+"use client";
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Cell,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+export type AdminTimelineRange = "7d" | "30d" | "90d";
+export type AdminTimelineView = "daily" | "weekly" | "monthly";
+
+export interface AdminStatsTimelinePoint {
+  periodKey: string;
+  label: string;
+  rangeLabel: string;
+  totalExams: number;
+  passedExams: number;
+  failedExams: number;
+  passRatePercent: number;
+  isPeak: boolean;
+}
+
+export interface AdminStatsTimelineData {
+  range: AdminTimelineRange;
+  view: AdminTimelineView;
+  timeZone: string;
+  points: AdminStatsTimelinePoint[];
+  peakTotalExams: number;
+  generatedAt: number;
+}
+
+interface AdminExamActivityTimelineProps {
+  data: AdminStatsTimelineData | null;
+  isLoading?: boolean;
+}
+
+interface TimelineTooltipPayloadItem {
+  payload?: AdminStatsTimelinePoint;
+}
+
+interface TimelineTooltipProps {
+  active?: boolean;
+  payload?: TimelineTooltipPayloadItem[];
+}
+
+function TimelineTooltip({ active, payload }: TimelineTooltipProps) {
+  if (!active || !payload || payload.length === 0) {
+    return null;
+  }
+
+  const point = payload[0]?.payload;
+  if (!point) {
+    return null;
+  }
+
+  return (
+    <div className="rounded-md border bg-background p-3 text-xs shadow-md">
+      <p className="font-semibold">{point.rangeLabel}</p>
+      <div className="mt-2 space-y-1 text-muted-foreground">
+        <p>
+          Total Exams: <span className="font-medium text-foreground">{point.totalExams}</span>
+        </p>
+        <p>
+          Passed: <span className="font-medium text-foreground">{point.passedExams}</span>
+        </p>
+        <p>
+          Failed: <span className="font-medium text-foreground">{point.failedExams}</span>
+        </p>
+        <p>
+          Pass Rate: <span className="font-medium text-foreground">{point.passRatePercent.toFixed(2)}%</span>
+        </p>
+        {point.isPeak ? (
+          <p className="font-medium text-primary">Peak testing period</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+function LoadingState() {
+  return (
+    <Card className="border-border/70">
+      <CardHeader>
+        <CardTitle>Exam Activity Timeline</CardTitle>
+        <CardDescription>Track official exam volume and outcomes over time.</CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <Skeleton className="h-72 w-full" />
+        <div className="grid grid-cols-3 gap-3">
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+          <Skeleton className="h-10 w-full" />
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+export function AdminExamActivityTimeline({ data, isLoading = false }: AdminExamActivityTimelineProps) {
+  if (isLoading && !data) {
+    return <LoadingState />;
+  }
+
+  if (!data) {
+    return (
+      <Card className="border-border/70">
+        <CardHeader>
+          <CardTitle>Exam Activity Timeline</CardTitle>
+          <CardDescription>Track official exam volume and outcomes over time.</CardDescription>
+        </CardHeader>
+        <CardContent className="text-sm text-muted-foreground">
+          Timeline data is currently unavailable.
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const hasActivity = data.points.some((point) => point.totalExams > 0);
+  const peakPeriods = data.points.filter((point) => point.isPeak && point.totalExams > 0);
+
+  return (
+    <Card className="border-border/70">
+      <CardHeader>
+        <CardTitle>Exam Activity Timeline</CardTitle>
+        <CardDescription>
+          Official exam activity in the selected period with pass/fail breakdown.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {!hasActivity ? (
+          <div className="rounded-md border border-dashed p-6 text-center text-sm text-muted-foreground">
+            No exam activity found for the selected range.
+          </div>
+        ) : (
+          <div className="h-80 w-full min-w-0">
+            <ResponsiveContainer width="100%" height={320} minWidth={0}>
+              <BarChart data={data.points} margin={{ top: 8, right: 10, left: -20, bottom: 0 }}>
+                <CartesianGrid
+                  strokeDasharray="3 3"
+                  vertical={false}
+                  stroke="hsl(var(--muted-foreground) / 0.2)"
+                />
+                <XAxis
+                  dataKey="label"
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{ fontSize: 12 }}
+                  stroke="hsl(var(--muted-foreground))"
+                  minTickGap={16}
+                />
+                <YAxis
+                  axisLine={false}
+                  tickLine={false}
+                  tick={{ fontSize: 12 }}
+                  stroke="hsl(var(--muted-foreground))"
+                  allowDecimals={false}
+                />
+                <Tooltip cursor={{ fill: "hsl(var(--muted) / 0.45)" }} content={<TimelineTooltip />} />
+                <Legend wrapperStyle={{ fontSize: "12px" }} />
+                <Bar dataKey="passedExams" stackId="exams" name="Passed" radius={[4, 4, 0, 0]}>
+                  {data.points.map((point) => (
+                    <Cell
+                      key={`passed-${point.periodKey}`}
+                      fill={point.isPeak ? "hsl(var(--primary))" : "hsl(var(--primary) / 0.65)"}
+                    />
+                  ))}
+                </Bar>
+                <Bar dataKey="failedExams" stackId="exams" name="Failed" radius={[4, 4, 0, 0]}>
+                  {data.points.map((point) => (
+                    <Cell
+                      key={`failed-${point.periodKey}`}
+                      fill={point.isPeak ? "hsl(var(--destructive))" : "hsl(var(--destructive) / 0.6)"}
+                    />
+                  ))}
+                </Bar>
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
+        )}
+
+        {hasActivity && peakPeriods.length > 0 ? (
+          <div className="rounded-md border bg-muted/30 px-3 py-2 text-xs text-muted-foreground">
+            Peak volume: <span className="font-medium text-foreground">{data.peakTotalExams}</span> exam(s) in{" "}
+            <span className="font-medium text-foreground">
+              {peakPeriods.slice(0, 3).map((point) => point.rangeLabel).join(", ")}
+              {peakPeriods.length > 3 ? ` (+${peakPeriods.length - 3} more)` : ""}
+            </span>
+            .
+          </div>
+        ) : null}
+      </CardContent>
+    </Card>
+  );
+}

--- a/convex/exams.ts
+++ b/convex/exams.ts
@@ -4,7 +4,10 @@ import { assertAdminUser } from "./exams/services/auth";
 
 export { getExamStartContext, getAttemptHistory } from "./exams/handlers/start";
 export { getExamGenerationSettings } from "./exams/handlers/settings";
-export { getAdminExamOverviewStats } from "./exams/handlers/adminStats";
+export {
+  getAdminExamOverviewStats,
+  getAdminExamActivityTimeline,
+} from "./exams/handlers/adminStats";
 export {
   getAttemptRuntimeProgress,
   getCurrentAttemptQuestion,

--- a/convex/exams/handlers/adminStats.ts
+++ b/convex/exams/handlers/adminStats.ts
@@ -1,5 +1,11 @@
+import { v } from "convex/values";
 import { query } from "../../_generated/server";
 import { getAuthenticatedUser } from "../services/auth";
+import {
+  buildAdminExamActivityTimeline,
+  getAdminTimelineRangeDays,
+  normalizeAdminTimelineTimeZone,
+} from "../services/activity-timeline";
 import { roundToTwoDecimals } from "../services/time";
 
 export const getAdminExamOverviewStats = query({
@@ -53,5 +59,41 @@ export const getAdminExamOverviewStats = query({
       uniqueTestTakers: uniqueUserIds.size,
       generatedAt: Date.now(),
     };
+  },
+});
+
+export const getAdminExamActivityTimeline = query({
+  args: {
+    range: v.optional(v.union(v.literal("7d"), v.literal("30d"), v.literal("90d"))),
+    view: v.optional(v.union(v.literal("daily"), v.literal("weekly"), v.literal("monthly"))),
+    timeZone: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const user = await getAuthenticatedUser(ctx);
+    if (!user || user.role !== "admin") {
+      return null;
+    }
+
+    const range = args.range ?? "30d";
+    const view = args.view ?? "daily";
+    const timeZone = normalizeAdminTimelineTimeZone(args.timeZone);
+
+    const rangeDays = getAdminTimelineRangeDays(range);
+    const cutoff = Date.now() - (rangeDays + 2) * 24 * 60 * 60 * 1000;
+
+    const results = await ctx.db
+      .query("examResults")
+      .withIndex("by_completedAt", (q) => q.gte("completedAt", cutoff))
+      .collect();
+
+    return buildAdminExamActivityTimeline({
+      results: results.map((result) => ({
+        completedAt: result.completedAt,
+        passed: result.passed,
+      })),
+      range,
+      view,
+      timeZone,
+    });
   },
 });

--- a/convex/exams/services/activity-timeline.ts
+++ b/convex/exams/services/activity-timeline.ts
@@ -1,0 +1,331 @@
+import { Doc } from "../../_generated/dataModel";
+import { roundToTwoDecimals } from "./time";
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const MONTH_LABELS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"] as const;
+
+export type AdminTimelineRange = "7d" | "30d" | "90d";
+export type AdminTimelineView = "daily" | "weekly" | "monthly";
+
+export interface AdminExamActivityPoint {
+  periodKey: string;
+  label: string;
+  rangeLabel: string;
+  totalExams: number;
+  passedExams: number;
+  failedExams: number;
+  passRatePercent: number;
+  isPeak: boolean;
+}
+
+export interface AdminExamActivityTimeline {
+  range: AdminTimelineRange;
+  view: AdminTimelineView;
+  timeZone: string;
+  points: AdminExamActivityPoint[];
+  peakTotalExams: number;
+  generatedAt: number;
+}
+
+interface BuildTimelineInput {
+  results: Array<Pick<Doc<"examResults">, "completedAt" | "passed">>;
+  range: AdminTimelineRange;
+  view: AdminTimelineView;
+  timeZone: string;
+  now?: number;
+}
+
+interface LocalDate {
+  year: number;
+  month: number;
+  day: number;
+}
+
+interface BucketCounter {
+  periodKey: string;
+  label: string;
+  rangeLabel: string;
+  totalExams: number;
+  passedExams: number;
+  failedExams: number;
+}
+
+const dateKeyFormatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getDateKeyFormatter(timeZone: string): Intl.DateTimeFormat {
+  const cached = dateKeyFormatterCache.get(timeZone);
+  if (cached) {
+    return cached;
+  }
+
+  const formatter = new Intl.DateTimeFormat("en-CA", {
+    timeZone,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  });
+  dateKeyFormatterCache.set(timeZone, formatter);
+  return formatter;
+}
+
+function toLocalDateKey(timestampMs: number, timeZone: string): string {
+  return getDateKeyFormatter(timeZone).format(new Date(timestampMs));
+}
+
+function parseDateKey(dateKey: string): LocalDate {
+  const [year, month, day] = dateKey.split("-").map((part) => Number(part));
+  return {
+    year,
+    month,
+    day,
+  };
+}
+
+function toDateKey(date: LocalDate): string {
+  return `${String(date.year).padStart(4, "0")}-${String(date.month).padStart(2, "0")}-${String(date.day).padStart(2, "0")}`;
+}
+
+function localDateToUtcDate(localDate: LocalDate): Date {
+  return new Date(Date.UTC(localDate.year, localDate.month - 1, localDate.day));
+}
+
+function utcDateToLocalDate(date: Date): LocalDate {
+  return {
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth() + 1,
+    day: date.getUTCDate(),
+  };
+}
+
+function addDays(dateKey: string, days: number): string {
+  const parsed = parseDateKey(dateKey);
+  const date = localDateToUtcDate(parsed);
+  date.setUTCDate(date.getUTCDate() + days);
+  return toDateKey(utcDateToLocalDate(date));
+}
+
+function getWeekStartDateKey(dateKey: string): string {
+  const parsed = parseDateKey(dateKey);
+  const date = localDateToUtcDate(parsed);
+  const weekday = date.getUTCDay();
+  const mondayOffset = weekday === 0 ? 6 : weekday - 1;
+  date.setUTCDate(date.getUTCDate() - mondayOffset);
+  return toDateKey(utcDateToLocalDate(date));
+}
+
+function getMonthStartDateKey(monthKey: string): string {
+  return `${monthKey}-01`;
+}
+
+function getMonthEndDateKey(monthKey: string): string {
+  const [year, month] = monthKey.split("-").map((part) => Number(part));
+  const endOfMonthUtc = new Date(Date.UTC(year, month, 0));
+  return toDateKey(utcDateToLocalDate(endOfMonthUtc));
+}
+
+function formatDateLabel(dateKey: string): string {
+  const { month, day } = parseDateKey(dateKey);
+  return `${MONTH_LABELS[month - 1]} ${day}`;
+}
+
+function formatMonthLabel(monthKey: string): string {
+  const [year, month] = monthKey.split("-").map((part) => Number(part));
+  return `${MONTH_LABELS[month - 1]} ${year}`;
+}
+
+function getRangeDays(range: AdminTimelineRange): number {
+  if (range === "7d") {
+    return 7;
+  }
+
+  if (range === "30d") {
+    return 30;
+  }
+
+  return 90;
+}
+
+function getPeriodKeyFromDateKey(dateKey: string, view: AdminTimelineView): string {
+  if (view === "daily") {
+    return dateKey;
+  }
+
+  if (view === "weekly") {
+    return getWeekStartDateKey(dateKey);
+  }
+
+  return dateKey.slice(0, 7);
+}
+
+function getPeriodLabels(periodKey: string, view: AdminTimelineView): {
+  label: string;
+  rangeLabel: string;
+} {
+  if (view === "daily") {
+    const label = formatDateLabel(periodKey);
+    return {
+      label,
+      rangeLabel: label,
+    };
+  }
+
+  if (view === "weekly") {
+    const endDate = addDays(periodKey, 6);
+    return {
+      label: formatDateLabel(periodKey),
+      rangeLabel: `${formatDateLabel(periodKey)} - ${formatDateLabel(endDate)}`,
+    };
+  }
+
+  const startDate = getMonthStartDateKey(periodKey);
+  const endDate = getMonthEndDateKey(periodKey);
+  return {
+    label: formatMonthLabel(periodKey),
+    rangeLabel: `${formatDateLabel(startDate)} - ${formatDateLabel(endDate)}`,
+  };
+}
+
+function enumeratePeriodKeys(input: {
+  range: AdminTimelineRange;
+  view: AdminTimelineView;
+  timeZone: string;
+  now: number;
+}): { startDateKey: string; endDateKey: string; periodKeys: string[] } {
+  const rangeDays = getRangeDays(input.range);
+  const endDateKey = toLocalDateKey(input.now, input.timeZone);
+  const startDateKey = toLocalDateKey(input.now - (rangeDays - 1) * DAY_MS, input.timeZone);
+
+  if (input.view === "daily") {
+    const keys: string[] = [];
+    let cursor = startDateKey;
+    while (cursor <= endDateKey) {
+      keys.push(cursor);
+      cursor = addDays(cursor, 1);
+    }
+    return { startDateKey, endDateKey, periodKeys: keys };
+  }
+
+  if (input.view === "weekly") {
+    const keys: string[] = [];
+    let cursor = getWeekStartDateKey(startDateKey);
+    const endWeekKey = getWeekStartDateKey(endDateKey);
+    while (cursor <= endWeekKey) {
+      keys.push(cursor);
+      cursor = addDays(cursor, 7);
+    }
+    return { startDateKey, endDateKey, periodKeys: keys };
+  }
+
+  const keys: string[] = [];
+  const startMonth = startDateKey.slice(0, 7);
+  const endMonth = endDateKey.slice(0, 7);
+  let cursorMonth = startMonth;
+
+  while (cursorMonth <= endMonth) {
+    keys.push(cursorMonth);
+    const [year, month] = cursorMonth.split("-").map((part) => Number(part));
+    const nextMonth = month === 12 ? { year: year + 1, month: 1 } : { year, month: month + 1 };
+    cursorMonth = `${String(nextMonth.year).padStart(4, "0")}-${String(nextMonth.month).padStart(2, "0")}`;
+  }
+
+  return { startDateKey, endDateKey, periodKeys: keys };
+}
+
+function isValidTimeZone(timeZone: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function normalizeAdminTimelineTimeZone(timeZone?: string): string {
+  if (!timeZone) {
+    return "UTC";
+  }
+
+  return isValidTimeZone(timeZone) ? timeZone : "UTC";
+}
+
+export function buildAdminExamActivityTimeline(input: BuildTimelineInput): AdminExamActivityTimeline {
+  const now = input.now ?? Date.now();
+  const { startDateKey, endDateKey, periodKeys } = enumeratePeriodKeys({
+    range: input.range,
+    view: input.view,
+    timeZone: input.timeZone,
+    now,
+  });
+
+  const buckets = new Map<string, BucketCounter>();
+  for (const periodKey of periodKeys) {
+    const labels = getPeriodLabels(periodKey, input.view);
+    buckets.set(periodKey, {
+      periodKey,
+      label: labels.label,
+      rangeLabel: labels.rangeLabel,
+      totalExams: 0,
+      passedExams: 0,
+      failedExams: 0,
+    });
+  }
+
+  for (const result of input.results) {
+    const resultDateKey = toLocalDateKey(result.completedAt, input.timeZone);
+    if (resultDateKey < startDateKey || resultDateKey > endDateKey) {
+      continue;
+    }
+
+    const periodKey = getPeriodKeyFromDateKey(resultDateKey, input.view);
+    const bucket = buckets.get(periodKey);
+    if (!bucket) {
+      continue;
+    }
+
+    bucket.totalExams += 1;
+    if (result.passed) {
+      bucket.passedExams += 1;
+    } else {
+      bucket.failedExams += 1;
+    }
+  }
+
+  let peakTotalExams = 0;
+  for (const bucket of buckets.values()) {
+    if (bucket.totalExams > peakTotalExams) {
+      peakTotalExams = bucket.totalExams;
+    }
+  }
+
+  const points: AdminExamActivityPoint[] = periodKeys.map((periodKey) => {
+    const bucket = buckets.get(periodKey)!;
+    const passRatePercent =
+      bucket.totalExams > 0
+        ? roundToTwoDecimals((bucket.passedExams / bucket.totalExams) * 100)
+        : 0;
+
+    return {
+      periodKey: bucket.periodKey,
+      label: bucket.label,
+      rangeLabel: bucket.rangeLabel,
+      totalExams: bucket.totalExams,
+      passedExams: bucket.passedExams,
+      failedExams: bucket.failedExams,
+      passRatePercent,
+      isPeak: peakTotalExams > 0 && bucket.totalExams === peakTotalExams,
+    };
+  });
+
+  return {
+    range: input.range,
+    view: input.view,
+    timeZone: input.timeZone,
+    points,
+    peakTotalExams,
+    generatedAt: now,
+  };
+}
+
+export function getAdminTimelineRangeDays(range: AdminTimelineRange): number {
+  return getRangeDays(range);
+}


### PR DESCRIPTION
## Summary
Implemented the **Exam Activity Timeline Visualization** for the Admin Dashboard, adding end-to-end support from Convex aggregation to secured API delivery and UI rendering.

---

## What Changed
- Added backend timeline aggregation for official exam activity with:
  - date ranges: `7d`, `30d`, `90d`
  - bucket views: `daily`, `weekly`, `monthly`
  - pass/fail totals, pass rate, and peak-period detection
  - timezone-aware bucketing (with safe fallback)
- Added a new admin-only Convex query:
  - `getAdminExamActivityTimeline`
- Added a secured admin API endpoint:
  - `GET /api/admin/stats/timeline`
  - validated query params (`range`, `view`, `timeZone`) via Zod
  - consistent error handling and response shape
  - parameter-aware caching
- Added new Admin Dashboard UI section:
  - range and view toggles
  - Recharts stacked pass/fail timeline visualization
  - peak testing period highlight
  - detailed hover tooltip per period
  - loading, error, and empty states
- Integrated the timeline section into `/admin`.

---

## Related Issue
Closes: https://github.com/Oak-Signal/oaksignal-signalsmaster/issues/208