### PR TITLE
209 dashboard exam list filtering

### DIFF
--- a/app/admin/exams/[examResultId]/page.tsx
+++ b/app/admin/exams/[examResultId]/page.tsx
@@ -1,0 +1,20 @@
+import { Id } from "@/convex/_generated/dataModel";
+import { AdminExamReviewClient } from "@/components/admin/admin-exam-review-client";
+
+interface AdminExamReviewPageProps {
+  params: Promise<{ examResultId: string }>;
+}
+
+export default async function AdminExamReviewPage({ params }: AdminExamReviewPageProps) {
+  const { examResultId } = await params;
+  const id = examResultId as Id<"examResults">;
+
+  return <AdminExamReviewClient examResultId={id} />;
+}
+
+export function generateMetadata() {
+  return {
+    title: "Admin Exam Review | Signals Master",
+    description: "Detailed administrator review of an official exam result.",
+  };
+}

--- a/app/admin/exams/page.tsx
+++ b/app/admin/exams/page.tsx
@@ -1,4 +1,4 @@
-import { Card, CardDescription, CardHeader, CardTitle } from "@/components/ui/card"
+import { AdminRecentExamAttemptsSection } from "@/components/admin/admin-recent-exam-attempts-section"
 
 export default function AdminExamManagementPage() {
   return (
@@ -6,18 +6,11 @@ export default function AdminExamManagementPage() {
       <div>
         <h2 className="text-3xl font-bold tracking-tight">Exam Management</h2>
         <p className="text-muted-foreground">
-          Administrative controls for official exam configuration will be implemented here.
+          Review recent official exam attempts and monitor cadet assessment outcomes.
         </p>
       </div>
 
-      <Card>
-        <CardHeader>
-          <CardTitle>Coming Soon</CardTitle>
-          <CardDescription>
-            This placeholder route keeps admin navigation functional while exam management features are delivered in follow-up stories.
-          </CardDescription>
-        </CardHeader>
-      </Card>
+      <AdminRecentExamAttemptsSection />
     </div>
   )
 }

--- a/app/api/admin/exams/route.ts
+++ b/app/api/admin/exams/route.ts
@@ -1,0 +1,74 @@
+import { ConvexHttpClient } from "convex/browser";
+import { z } from "zod";
+
+import { api } from "@/convex/_generated/api";
+import {
+  ADMIN_EXAMS_DEFAULT_LIMIT,
+  ADMIN_EXAMS_DEFAULT_PAGE,
+  ADMIN_EXAMS_MAX_LIMIT,
+  AdminRecentExamAttemptsPayload,
+} from "@/lib/admin-exams-types";
+import { adminApiErrorResponse, withAdminApiGuard } from "@/lib/api/admin-handler";
+
+const examsQuerySchema = z.object({
+  page: z.coerce.number().int().min(1).default(ADMIN_EXAMS_DEFAULT_PAGE),
+  limit: z.coerce.number().int().min(1).max(ADMIN_EXAMS_MAX_LIMIT).default(ADMIN_EXAMS_DEFAULT_LIMIT),
+});
+
+interface AdminExamsSuccessResponse {
+  success: true;
+  data: AdminRecentExamAttemptsPayload;
+}
+
+export const GET = withAdminApiGuard(async (req, { convexToken }) => {
+  const url = new URL(req.url);
+  const parsedQuery = examsQuerySchema.safeParse({
+    page: url.searchParams.get("page") ?? undefined,
+    limit: url.searchParams.get("limit") ?? undefined,
+  });
+
+  if (!parsedQuery.success) {
+    return adminApiErrorResponse(400, "INVALID_QUERY", "Invalid exams query parameters.");
+  }
+
+  const convexUrl = process.env.NEXT_PUBLIC_CONVEX_URL;
+  if (!convexUrl) {
+    return adminApiErrorResponse(
+      500,
+      "SERVER_MISCONFIGURED",
+      "Convex URL is not configured."
+    );
+  }
+
+  try {
+    const convex = new ConvexHttpClient(convexUrl);
+    convex.setAuth(convexToken);
+
+    const data = await convex.query(api.exams.getAdminRecentExamAttempts, {
+      page: parsedQuery.data.page,
+      limit: parsedQuery.data.limit,
+    });
+
+    if (!data) {
+      return adminApiErrorResponse(403, "FORBIDDEN", "Administrator access is required.");
+    }
+
+    const body: AdminExamsSuccessResponse = {
+      success: true,
+      data,
+    };
+
+    return Response.json(body, {
+      status: 200,
+      headers: {
+        "Cache-Control": "private, no-store",
+      },
+    });
+  } catch {
+    return adminApiErrorResponse(
+      500,
+      "INTERNAL_ERROR",
+      "Failed to fetch recent exam attempts."
+    );
+  }
+});

--- a/components/admin/admin-exam-review-client.tsx
+++ b/components/admin/admin-exam-review-client.tsx
@@ -1,0 +1,316 @@
+"use client";
+
+import Link from "next/link";
+import Image from "next/image";
+import { useEffect, useState } from "react";
+import { format } from "date-fns";
+import { useMutation } from "convex/react";
+
+import { Id } from "@/convex/_generated/dataModel";
+import { api } from "@/convex/_generated/api";
+import { OfficialExamResult } from "@/lib/exam-types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface AdminExamReviewClientProps {
+  examResultId: Id<"examResults">;
+}
+
+function formatDateTime(value: number): string {
+  return format(value, "PPp");
+}
+
+function formatDuration(durationMs: number): string {
+  if (!Number.isFinite(durationMs) || durationMs < 0) {
+    return "N/A";
+  }
+
+  const totalSeconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes === 0) {
+    return `${seconds}s`;
+  }
+
+  return `${minutes}m ${seconds}s`;
+}
+
+function formatScorePercent(scorePercent: number): string {
+  return `${scorePercent.toFixed(2)}%`;
+}
+
+function formatResponseTime(value: number | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) {
+    return "Not tracked";
+  }
+
+  if (value < 1000) {
+    return `${value} ms`;
+  }
+
+  const seconds = value / 1000;
+  if (seconds < 60) {
+    return `${seconds.toFixed(1)} sec`;
+  }
+
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = Math.round(seconds % 60);
+  return `${minutes}m ${remainingSeconds}s`;
+}
+
+function getOptionLabel(
+  options: Array<{ id: string; label: string; value: string }>,
+  optionId: string | null
+): string {
+  if (!optionId) {
+    return "No answer submitted";
+  }
+
+  const option = options.find((item) => item.id === optionId);
+  if (!option) {
+    return optionId;
+  }
+
+  return option.label?.trim() ? option.label : option.value;
+}
+
+export function AdminExamReviewClient({ examResultId }: AdminExamReviewClientProps) {
+  const getOfficialResultForAdminReview = useMutation(api.exams.getOfficialResultForAdminReview);
+  const [result, setResult] = useState<OfficialExamResult | null | undefined>(undefined);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void getOfficialResultForAdminReview({ examResultId })
+      .then((data) => {
+        if (cancelled) {
+          return;
+        }
+
+        setResult((data as OfficialExamResult | null) ?? null);
+        setErrorMessage(null);
+      })
+      .catch(() => {
+        if (cancelled) {
+          return;
+        }
+        setResult(null);
+        setErrorMessage("Failed to load official exam result.");
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [examResultId, getOfficialResultForAdminReview]);
+
+  if (result === undefined) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Loading exam review...</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <p className="text-sm text-muted-foreground">
+              Retrieving immutable exam result details.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (errorMessage) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Unable to Load Exam Review</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-destructive">{errorMessage}</p>
+            <Button asChild variant="outline">
+              <Link href="/admin/exams">Back to Exam Management</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  if (!result) {
+    return (
+      <div className="space-y-4">
+        <Card>
+          <CardHeader>
+            <CardTitle>Result Not Found</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <p className="text-sm text-muted-foreground">
+              This exam result does not exist or you do not have access to review it.
+            </p>
+            <Button asChild variant="outline">
+              <Link href="/admin/exams">Back to Exam Management</Link>
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const durationMs = result.completedAt - result.startedAt;
+
+  return (
+    <div className="space-y-6">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h2 className="text-2xl font-bold tracking-tight">Exam Result Review</h2>
+          <p className="text-sm text-muted-foreground">
+            Immutable certificate review for {result.userSnapshot.fullName}
+          </p>
+        </div>
+        <Button asChild variant="outline">
+          <Link href="/admin/exams">Back to Exam Management</Link>
+        </Button>
+      </div>
+
+      <Card className="border-border/70">
+        <CardHeader>
+          <div className="flex flex-wrap items-start justify-between gap-3">
+            <div>
+              <CardTitle className="text-xl">Certificate #{result.certificateNumber}</CardTitle>
+              <p className="mt-1 text-sm text-muted-foreground">
+                Attempt #{result.attemptNumber} completed on {formatDateTime(result.completedAt)}
+              </p>
+            </div>
+            <Badge
+              className={
+                result.passed
+                  ? "border-emerald-200 bg-emerald-100 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-200"
+                  : "border-red-200 bg-red-100 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200"
+              }
+            >
+              {result.passed ? "Passed" : "Failed"}
+            </Badge>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-3 rounded-md border bg-muted/20 p-4 text-sm md:grid-cols-2 xl:grid-cols-4">
+            <div>
+              <p className="text-muted-foreground">Cadet</p>
+              <p className="font-medium">{result.userSnapshot.fullName}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">Started</p>
+              <p className="font-medium">{formatDateTime(result.startedAt)}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">Completed</p>
+              <p className="font-medium">{formatDateTime(result.completedAt)}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">Duration</p>
+              <p className="font-medium">{formatDuration(durationMs)}</p>
+            </div>
+          </div>
+
+          <div className="grid gap-3 rounded-md border bg-background p-4 text-sm md:grid-cols-3">
+            <div>
+              <p className="text-muted-foreground">Score</p>
+              <p className="text-lg font-semibold">{formatScorePercent(result.scorePercent)}</p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">Correct</p>
+              <p className="text-lg font-semibold">
+                {result.totalCorrect}/{result.totalQuestions}
+              </p>
+            </div>
+            <div>
+              <p className="text-muted-foreground">Pass Threshold</p>
+              <p className="text-lg font-semibold">{formatScorePercent(result.passThresholdPercent)}</p>
+            </div>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card className="border-border/70">
+        <CardHeader>
+          <CardTitle className="text-lg">Question-by-Question Review</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {result.questionBreakdown
+            .slice()
+            .sort((a, b) => a.questionIndex - b.questionIndex)
+            .map((question) => {
+              const selectedAnswerLabel = getOptionLabel(question.options, question.selectedAnswer);
+              const correctAnswerLabel = getOptionLabel(question.options, question.correctAnswer);
+              const showCorrectAnswer = question.isCorrect !== true;
+
+              return (
+                <div key={question.questionIndex} className="rounded-md border bg-background p-3">
+                  <div className="flex flex-wrap items-center justify-between gap-2">
+                    <div className="flex items-center gap-2">
+                      <p className="text-sm font-medium">Question {question.questionIndex + 1}</p>
+                      <Badge variant="outline" className="text-[10px] uppercase tracking-wide">
+                        {question.mode}
+                      </Badge>
+                    </div>
+                    <Badge
+                      className={
+                        question.isCorrect
+                          ? "border-emerald-200 bg-emerald-100 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-200"
+                          : "border-red-200 bg-red-100 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200"
+                      }
+                    >
+                      {question.isCorrect ? "Correct" : "Incorrect"}
+                    </Badge>
+                  </div>
+
+                  <div className="mt-3 flex gap-3">
+                    <div className="h-14 w-20 shrink-0 overflow-hidden rounded border bg-muted">
+                      {question.flagImagePath ? (
+                        <Image
+                          src={question.flagImagePath}
+                          alt={`${question.flagName} flag thumbnail`}
+                          width={80}
+                          height={56}
+                          className="h-full w-full object-cover"
+                        />
+                      ) : (
+                        <div className="flex h-full items-center justify-center text-[10px] text-muted-foreground">
+                          No image
+                        </div>
+                      )}
+                    </div>
+
+                    <div className="min-w-0 flex-1 space-y-1 text-sm">
+                      <p className="font-medium">{question.flagName}</p>
+                      <p className="text-xs text-muted-foreground">Category: {question.category}</p>
+                      <p>
+                        <span className="text-muted-foreground">Selected:</span>{" "}
+                        <span className={question.isCorrect ? "font-medium" : "font-medium text-destructive"}>
+                          {selectedAnswerLabel}
+                        </span>
+                      </p>
+                      {showCorrectAnswer ? (
+                        <p>
+                          <span className="text-muted-foreground">Correct:</span>{" "}
+                          <span className="font-medium">{correctAnswerLabel}</span>
+                        </p>
+                      ) : null}
+                      <p className="text-xs text-muted-foreground">
+                        Response time: {formatResponseTime(question.responseTimeMs)}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/components/admin/admin-recent-exam-attempts-section.tsx
+++ b/components/admin/admin-recent-exam-attempts-section.tsx
@@ -83,6 +83,25 @@ export function AdminRecentExamAttemptsSection() {
     totalPages: 0,
   };
 
+  const handlePageChange = useCallback(
+    (nextPage: number) => {
+      if (!Number.isInteger(nextPage) || nextPage < 1) {
+        return;
+      }
+
+      if (pagination.totalPages > 0 && nextPage > pagination.totalPages) {
+        return;
+      }
+
+      if (nextPage === page) {
+        return;
+      }
+
+      setPage(nextPage);
+    },
+    [page, pagination.totalPages]
+  );
+
   return (
     <div className="space-y-2">
       {errorMessage ? (
@@ -95,7 +114,7 @@ export function AdminRecentExamAttemptsSection() {
         items={data?.items ?? []}
         pagination={pagination}
         isLoading={isLoading}
-        onPageChange={setPage}
+        onPageChange={handlePageChange}
       />
     </div>
   );

--- a/components/admin/admin-recent-exam-attempts-section.tsx
+++ b/components/admin/admin-recent-exam-attempts-section.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import {
+  ADMIN_EXAMS_DEFAULT_LIMIT,
+  ADMIN_EXAMS_DEFAULT_PAGE,
+  AdminRecentExamAttemptsPayload,
+} from "@/lib/admin-exams-types";
+import { AdminRecentExamAttemptsTable } from "@/components/admin/admin-recent-exam-attempts-table";
+
+interface AdminExamsSuccessResponse {
+  success: true;
+  data: AdminRecentExamAttemptsPayload;
+}
+
+interface AdminExamsErrorResponse {
+  success: false;
+  error?: {
+    message?: string;
+  };
+}
+
+export function AdminRecentExamAttemptsSection() {
+  const [page, setPage] = useState<number>(ADMIN_EXAMS_DEFAULT_PAGE);
+  const [data, setData] = useState<AdminRecentExamAttemptsPayload | null>(null);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const fetchAttempts = useCallback(async (pageToLoad: number) => {
+    setIsLoading(true);
+
+    try {
+      const params = new URLSearchParams({
+        page: String(pageToLoad),
+        limit: String(ADMIN_EXAMS_DEFAULT_LIMIT),
+      });
+
+      const response = await fetch(`/api/admin/exams?${params.toString()}`, {
+        method: "GET",
+        cache: "no-store",
+        credentials: "same-origin",
+        headers: {
+          Accept: "application/json",
+        },
+      });
+
+      const body = (await response.json()) as
+        | AdminExamsSuccessResponse
+        | AdminExamsErrorResponse;
+
+      if (!response.ok) {
+        const message =
+          body && "error" in body && body.error?.message
+            ? body.error.message
+            : "Unable to load recent exam attempts.";
+        throw new Error(message);
+      }
+
+      if (!body || !("success" in body) || !body.success || !("data" in body)) {
+        throw new Error("Unexpected recent exam attempts response.");
+      }
+
+      setData(body.data);
+      setErrorMessage(null);
+    } catch (error) {
+      const message =
+        error instanceof Error ? error.message : "Unable to load recent exam attempts.";
+      setErrorMessage(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void fetchAttempts(page);
+  }, [fetchAttempts, page]);
+
+  const pagination = data?.pagination ?? {
+    page,
+    limit: ADMIN_EXAMS_DEFAULT_LIMIT,
+    totalCount: 0,
+    totalPages: 0,
+  };
+
+  return (
+    <div className="space-y-2">
+      {errorMessage ? (
+        <p className="text-sm text-destructive" role="status" aria-live="polite">
+          {errorMessage}
+        </p>
+      ) : null}
+
+      <AdminRecentExamAttemptsTable
+        items={data?.items ?? []}
+        pagination={pagination}
+        isLoading={isLoading}
+        onPageChange={setPage}
+      />
+    </div>
+  );
+}

--- a/components/admin/admin-recent-exam-attempts-table.tsx
+++ b/components/admin/admin-recent-exam-attempts-table.tsx
@@ -88,15 +88,15 @@ export function AdminRecentExamAttemptsTable({
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
-        <div className="overflow-x-auto rounded-md border">
+        <div className="overflow-x-auto rounded-md border" aria-busy={isLoading}>
           <table className="w-full min-w-[760px] text-sm" aria-label="Recent exam attempts">
             <thead className="bg-muted/50">
               <tr>
-                <th className="px-4 py-3 text-left font-medium">Cadet</th>
-                <th className="px-4 py-3 text-left font-medium">Date/Time</th>
-                <th className="px-4 py-3 text-left font-medium">Score</th>
-                <th className="px-4 py-3 text-left font-medium">Status</th>
-                <th className="px-4 py-3 text-left font-medium">Duration</th>
+                <th scope="col" className="px-4 py-3 text-left font-medium">Cadet</th>
+                <th scope="col" className="px-4 py-3 text-left font-medium">Date/Time</th>
+                <th scope="col" className="px-4 py-3 text-left font-medium">Score</th>
+                <th scope="col" className="px-4 py-3 text-left font-medium">Status</th>
+                <th scope="col" className="px-4 py-3 text-left font-medium">Duration</th>
               </tr>
             </thead>
             <tbody>

--- a/components/admin/admin-recent-exam-attempts-table.tsx
+++ b/components/admin/admin-recent-exam-attempts-table.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import Link from "next/link";
+import { format } from "date-fns";
+
+import {
+  AdminRecentExamAttemptItem,
+  AdminRecentExamAttemptsPagination,
+} from "@/lib/admin-exams-types";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Skeleton } from "@/components/ui/skeleton";
+
+interface AdminRecentExamAttemptsTableProps {
+  items: AdminRecentExamAttemptItem[];
+  pagination: AdminRecentExamAttemptsPagination;
+  isLoading?: boolean;
+  onPageChange: (page: number) => void;
+}
+
+function formatScorePercent(score: number): string {
+  return `${score.toFixed(2)}%`;
+}
+
+function formatCompletedAt(timestamp: number): string {
+  return format(timestamp, "PPp");
+}
+
+function formatDuration(durationMs: number | null): string {
+  if (durationMs === null || durationMs < 0) {
+    return "N/A";
+  }
+
+  const totalSeconds = Math.floor(durationMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+
+  if (minutes === 0) {
+    return `${seconds}s`;
+  }
+
+  return `${minutes}m ${seconds}s`;
+}
+
+function getPageNumbers(currentPage: number, totalPages: number): number[] {
+  if (totalPages <= 7) {
+    return Array.from({ length: totalPages }, (_, index) => index + 1);
+  }
+
+  const pages = new Set<number>([1, totalPages, currentPage - 1, currentPage, currentPage + 1]);
+  return [...pages].filter((page) => page >= 1 && page <= totalPages).sort((a, b) => a - b);
+}
+
+function LoadingRows() {
+  return (
+    <>
+      {Array.from({ length: 6 }).map((_, index) => (
+        <tr key={`loading-row-${index}`} className="border-b last:border-b-0">
+          <td className="px-4 py-3"><Skeleton className="h-4 w-32" /></td>
+          <td className="px-4 py-3"><Skeleton className="h-4 w-40" /></td>
+          <td className="px-4 py-3"><Skeleton className="h-4 w-16" /></td>
+          <td className="px-4 py-3"><Skeleton className="h-6 w-20 rounded-full" /></td>
+          <td className="px-4 py-3"><Skeleton className="h-4 w-14" /></td>
+        </tr>
+      ))}
+    </>
+  );
+}
+
+export function AdminRecentExamAttemptsTable({
+  items,
+  pagination,
+  isLoading = false,
+  onPageChange,
+}: AdminRecentExamAttemptsTableProps) {
+  const hasItems = items.length > 0;
+  const pageNumbers = getPageNumbers(pagination.page, pagination.totalPages);
+  const canGoPrevious = pagination.page > 1;
+  const canGoNext = pagination.page < pagination.totalPages;
+
+  return (
+    <Card className="border-border/70">
+      <CardHeader>
+        <CardTitle>Recent Exam Attempts</CardTitle>
+        <CardDescription>
+          Review the latest completed official exam activity.
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <div className="overflow-x-auto rounded-md border">
+          <table className="w-full min-w-[760px] text-sm" aria-label="Recent exam attempts">
+            <thead className="bg-muted/50">
+              <tr>
+                <th className="px-4 py-3 text-left font-medium">Cadet</th>
+                <th className="px-4 py-3 text-left font-medium">Date/Time</th>
+                <th className="px-4 py-3 text-left font-medium">Score</th>
+                <th className="px-4 py-3 text-left font-medium">Status</th>
+                <th className="px-4 py-3 text-left font-medium">Duration</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                <LoadingRows />
+              ) : hasItems ? (
+                items.map((item) => (
+                  <tr key={item.examResultId} className="border-b transition-colors hover:bg-muted/30 last:border-b-0">
+                    <td className="px-4 py-3 font-medium">
+                      <Link
+                        href={`/admin/exams/${item.examResultId}`}
+                        className="rounded-sm underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                        aria-label={`Open exam review for ${item.cadetName}`}
+                      >
+                        {item.cadetName}
+                      </Link>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">{formatCompletedAt(item.completedAt)}</td>
+                    <td className="px-4 py-3">{formatScorePercent(item.scorePercent)}</td>
+                    <td className="px-4 py-3">
+                      <Badge
+                        className={
+                          item.passed
+                            ? "border-emerald-200 bg-emerald-100 text-emerald-800 dark:border-emerald-800 dark:bg-emerald-950 dark:text-emerald-200"
+                            : "border-red-200 bg-red-100 text-red-800 dark:border-red-800 dark:bg-red-950 dark:text-red-200"
+                        }
+                      >
+                        {item.passed ? "Passed" : "Failed"}
+                      </Badge>
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground">{formatDuration(item.durationMs)}</td>
+                  </tr>
+                ))
+              ) : (
+                <tr>
+                  <td colSpan={5} className="px-4 py-10 text-center text-muted-foreground">
+                    No exams found.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+          <p className="text-xs text-muted-foreground">
+            {pagination.totalCount === 0
+              ? "0 results"
+              : `Showing page ${pagination.page} of ${Math.max(pagination.totalPages, 1)} (${pagination.totalCount} total)`}
+          </p>
+
+          <div className="flex flex-wrap items-center gap-2" role="navigation" aria-label="Pagination">
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => onPageChange(pagination.page - 1)}
+              disabled={!canGoPrevious || isLoading}
+              aria-label="Go to previous page"
+            >
+              Previous
+            </Button>
+
+            {pageNumbers.map((pageNumber) => (
+              <Button
+                key={pageNumber}
+                type="button"
+                variant={pageNumber === pagination.page ? "default" : "outline"}
+                size="sm"
+                onClick={() => onPageChange(pageNumber)}
+                disabled={isLoading}
+                aria-label={`Go to page ${pageNumber}`}
+                aria-current={pageNumber === pagination.page ? "page" : undefined}
+              >
+                {pageNumber}
+              </Button>
+            ))}
+
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => onPageChange(pagination.page + 1)}
+              disabled={!canGoNext || isLoading}
+              aria-label="Go to next page"
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/convex/exams.ts
+++ b/convex/exams.ts
@@ -8,6 +8,7 @@ export {
   getAdminExamOverviewStats,
   getAdminExamActivityTimeline,
 } from "./exams/handlers/adminStats";
+export { getAdminRecentExamAttempts } from "./exams/handlers/admin-exams";
 export {
   getAttemptRuntimeProgress,
   getCurrentAttemptQuestion,

--- a/convex/exams/handlers/admin-exams.ts
+++ b/convex/exams/handlers/admin-exams.ts
@@ -1,0 +1,88 @@
+import { query } from "../../_generated/server";
+import { v } from "convex/values";
+
+import { getAuthenticatedUser } from "../services/auth";
+
+const DEFAULT_PAGE = 1;
+const DEFAULT_LIMIT = 25;
+const MAX_LIMIT = 100;
+
+function normalizePage(value: number | undefined): number {
+  if (!value || !Number.isInteger(value) || value < 1) {
+    return DEFAULT_PAGE;
+  }
+  return value;
+}
+
+function normalizeLimit(value: number | undefined): number {
+  if (!value || !Number.isInteger(value) || value < 1) {
+    return DEFAULT_LIMIT;
+  }
+
+  return Math.min(value, MAX_LIMIT);
+}
+
+function calculateDurationMs(startedAt: number, completedAt: number): number | null {
+  if (!Number.isFinite(startedAt) || !Number.isFinite(completedAt)) {
+    return null;
+  }
+
+  const duration = completedAt - startedAt;
+  return duration >= 0 ? duration : null;
+}
+
+export const getAdminRecentExamAttempts = query({
+  args: {
+    page: v.optional(v.number()),
+    limit: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const user = await getAuthenticatedUser(ctx);
+    if (!user || user.role !== "admin") {
+      return null;
+    }
+
+    const requestedPage = normalizePage(args.page);
+    const limit = normalizeLimit(args.limit);
+
+    const allResults = await ctx.db
+      .query("examResults")
+      .withIndex("by_completedAt")
+      .collect();
+
+    const totalCount = allResults.length;
+    const totalPages = totalCount === 0 ? 0 : Math.ceil(totalCount / limit);
+    const page =
+      totalPages === 0 ? DEFAULT_PAGE : Math.min(requestedPage, totalPages);
+
+    const startIndex = (page - 1) * limit;
+    const pageWindowSize = startIndex + limit;
+
+    const descWindow = await ctx.db
+      .query("examResults")
+      .withIndex("by_completedAt")
+      .order("desc")
+      .take(pageWindowSize);
+
+    const pageItems = descWindow.slice(startIndex, startIndex + limit);
+
+    return {
+      items: pageItems.map((result) => ({
+        examResultId: result._id,
+        examAttemptId: result.examAttemptId,
+        cadetName: result.userSnapshot.fullName,
+        completedAt: result.completedAt,
+        scorePercent: result.scorePercent,
+        passed: result.passed,
+        durationMs: calculateDurationMs(result.startedAt, result.completedAt),
+      })),
+      pagination: {
+        page,
+        limit,
+        totalCount,
+        totalPages,
+      },
+      generatedAt: Date.now(),
+    };
+  },
+});

--- a/lib/admin-exams-types.ts
+++ b/lib/admin-exams-types.ts
@@ -1,0 +1,26 @@
+export const ADMIN_EXAMS_DEFAULT_PAGE = 1;
+export const ADMIN_EXAMS_DEFAULT_LIMIT = 25;
+export const ADMIN_EXAMS_MAX_LIMIT = 100;
+
+export interface AdminRecentExamAttemptItem {
+  examResultId: string;
+  examAttemptId: string;
+  cadetName: string;
+  completedAt: number;
+  scorePercent: number;
+  passed: boolean;
+  durationMs: number | null;
+}
+
+export interface AdminRecentExamAttemptsPagination {
+  page: number;
+  limit: number;
+  totalCount: number;
+  totalPages: number;
+}
+
+export interface AdminRecentExamAttemptsPayload {
+  items: AdminRecentExamAttemptItem[];
+  pagination: AdminRecentExamAttemptsPagination;
+  generatedAt: number;
+}


### PR DESCRIPTION
## Summary
Implemented the **Admin Recent Exam Attempts List with Pagination** for the Admin Dashboard, delivering end-to-end support from Convex data retrieval to secured API delivery and admin UI drilldown.

## What Changed
- Added backend pagination query for recent official exam attempts with:
  - default `25` per page
  - descending recent-first ordering by completion time
  - total count + total pages for pagination controls
  - derived attempt duration
  - admin-only access enforcement
- Added shared typed contracts/constants for admin exam list payloads.
- Added secured admin API endpoint:
  - `GET /api/admin/exams`
  - validated `page`/`limit` query params via Zod
  - consistent admin error response shape
  - guarded by existing admin auth/authorization flow
- Replaced the admin exams placeholder with a live UI section featuring:
  - tabular recent attempts (Cadet, Date/Time, Score, Status, Duration)
  - pass/fail badges (`Passed` green, `Failed` red)
  - pagination controls (Previous, Next, page numbers)
  - loading skeleton, error handling, and empty state (`No exams found`)
- Added row drilldown support to a dedicated admin exam review page:
  - detailed immutable result review
  - loading/error/not-found states
  - question-by-question breakdown for admin auditing
- Applied hardening refinements:
  - guard invalid/out-of-range page navigation
  - accessibility improvements for table loading/headers.